### PR TITLE
Complete the example code & fix compilation errors

### DIFF
--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -21,7 +21,7 @@ Create a ifan02.h file:
     #include "esphome.h"
     using namespace esphome;
 
-    class IFan02Output : public output::FloatOutput {
+    class IFan02Output : public Component, public FloatOutput {
       public:
         void write_state(float state) override {
           if (state < 0.3) {
@@ -58,6 +58,21 @@ Then you need to set it up with yaml.
       board: esp8285
       includes:
         - ifan02.h
+      on_boot:
+        priority: 225
+        # turn off the light as early as possible
+        then:
+          - light.turn_off: ifan02_light
+    
+    wifi:
+      ssid: <YOUR_SSID>
+      password: <YOUR_PASSWORD>
+
+    api:
+
+    logger:
+
+    ota:
 
     binary_sensor:
       - platform: gpio
@@ -67,7 +82,7 @@ Then you need to set it up with yaml.
           inverted: True
         on_press:
           then:
-            - light.toggle: light
+            - light.toggle: ifan02_light
 
       - platform: gpio
         id: vbutton_relay_1
@@ -105,9 +120,9 @@ Then you need to set it up with yaml.
         outputs:
           id: fanoutput
         lambda: |-
-          auto ifan02 = new IFan02Output();
-          App.register_component(ifan02);
-          return {ifan02};
+          auto ifan02_fan = new IFan02Output();
+          App.register_component(ifan02_fan);
+          return {ifan02_fan};
 
       - platform: gpio
         pin: GPIO12
@@ -115,9 +130,9 @@ Then you need to set it up with yaml.
 
     light:
       - platform: binary
-        name: ifan02_light
+        name: "iFan02 Light"
         output: light_output
-        id: light
+        id: ifan02_light
 
     switch:
       - platform: template
@@ -133,7 +148,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay2
                     - switch.is_off: fan_relay3
                 then:
-                  - fan.turn_off: ifan02
+                  - fan.turn_off: ifan02_fan
             - if:
                 condition:
                   and:
@@ -142,7 +157,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay3
                 then:
                   - fan.turn_on:
-                      id: ifan02
+                      id: ifan02_fan
                       speed: LOW
             - if:
                 condition:
@@ -152,7 +167,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay3
                 then:
                   - fan.turn_on:
-                      id: ifan02
+                      id: ifan02_fan
                       speed: MEDIUM
             - if:
                 condition:
@@ -162,7 +177,7 @@ Then you need to set it up with yaml.
                     - switch.is_on: fan_relay3
                 then:
                   - fan.turn_on:
-                      id: ifan02
+                      id: ifan02_fan
                       speed: HIGH
             - switch.turn_off: update_fan_speed
 
@@ -181,8 +196,8 @@ Then you need to set it up with yaml.
     fan:
       - platform: speed
         output: fanoutput
-        id: ifan02
-        name: ifan02_fan
+        id: ifan02_fan
+        name: "iFan02 Fan"
 
 See Also
 --------


### PR DESCRIPTION
Tried compiling this code today using ESPHome 1.13.6.. it would not compile. 

* The class delcaration in ifan02.h was the main culprit and I was able to fix the issue.

* The .yaml example was missing a few declarations at the beginning so I added them.
* I fixed an error related to using ```light``` for the light id since that is a reserved name.
* I added an ```on_boot``` declaration to turn off the light as early as possible after power is restored. (if mains power is restored in the middle of the night and the light turns on while you are sleeping it can be quite annoying, this turns it off during the boot process).

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
