### PR TITLE
Ifan02

### DIFF
--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -54,47 +54,47 @@ Then you need to set it up with yaml.
       board: esp8285
       includes:
         - ifan02.h
-    
+
     binary_sensor:
       - platform: gpio
         id: vbutton_light
-        pin: 
+        pin:
           number: GPIO0
           inverted: True
         on_press:
           then:
             - light.toggle: light
-    
+
       - platform: gpio
         id: vbutton_relay_1
-        pin: 
+        pin:
           number: GPIO9
           inverted: True
         on_press:
           then:
             - switch.toggle: fan_relay1
             - switch.turn_on: update_fan_speed
-    
+
       - platform: gpio
         id: vbutton_relay_2
-        pin: 
+        pin:
           number: GPIO10
           inverted: True
         on_press:
           then:
             - switch.toggle: fan_relay2
             - switch.turn_on: update_fan_speed
-            
+
       - platform: gpio
         id: vbutton_relay_3
-        pin: 
+        pin:
           number: GPIO14
           inverted: True
         on_press:
           then:
             - switch.toggle: fan_relay3
             - switch.turn_on: update_fan_speed
-    
+
     output:
       - platform: custom
         type: float
@@ -104,17 +104,17 @@ Then you need to set it up with yaml.
           auto ifan02 = new IFan02Output();
           App.register_component(ifan02);
           return {ifan02};
-          
+
       - platform: gpio
         pin: GPIO12
         id: light_output
-    
+
     light:
       - platform: binary
         name: ifan02_light
         output: light_output
         id: light
-    
+
     switch:
       - platform: template
         id: update_fan_speed
@@ -122,7 +122,7 @@ Then you need to set it up with yaml.
         turn_on_action:
           then:
             - delay: 200ms
-            - if: 
+            - if:
                 condition:
                   and:
                     - switch.is_off: fan_relay1
@@ -137,7 +137,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay2
                     - switch.is_off: fan_relay3
                 then:
-                  - fan.turn_on: 
+                  - fan.turn_on:
                       id: ifan02
                       speed: LOW
             - if:
@@ -147,7 +147,7 @@ Then you need to set it up with yaml.
                     - switch.is_on: fan_relay2
                     - switch.is_off: fan_relay3
                 then:
-                  - fan.turn_on: 
+                  - fan.turn_on:
                       id: ifan02
                       speed: MEDIUM
             - if:
@@ -157,23 +157,23 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay2
                     - switch.is_on: fan_relay3
                 then:
-                  - fan.turn_on: 
+                  - fan.turn_on:
                       id: ifan02
                       speed: HIGH
             - switch.turn_off: update_fan_speed
-    
+
       - platform: gpio
         pin: GPIO5
         id: fan_relay1
-        
+
       - platform: gpio
         pin: GPIO4
         id: fan_relay2
-        
+
       - platform: gpio
         pin: GPIO15
         id: fan_relay3
-    
+
     fan:
       - platform: speed
         output: fanoutput

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -10,9 +10,9 @@ Sonoff iFan02 is a driver for ceiling fans with lights.
 By replacing the old driver with iFan02, your non-smart led ceiling fan will be converted to a smart ceiling fan.
 For more information see `iFan02 <https://www.itead.cc/sonoff-ifan02-wifi-smart-ceiling-fan-with-light.html>`__
 
-This configuration will expose a :doc:`components/light/binary` and a :doc:`components/fan/speed`.
+This configuration will expose a :doc:`/components/light/binary` and a :doc:`/components/fan/speed`.
 
-To get this working in ESPHome you first need to create a :doc:`components/output/custom` to control the iFan02.
+To get this working in ESPHome you first need to create a :doc:`/components/output/custom` to control the iFan02.
 
 Create a ifan02.h file:
 

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -4,6 +4,7 @@ Sonoff iFan02
 .. seo::
     :description: Instructions for using Sonoff ifan02 in ESPHome.
     :keywords: Fan, Sonoff, ifan02
+    :image: fan.svg
 
 Sonoff iFan02 is a driver for ceiling fans with lights. 
 By replacing the old driver with iFan02, your non-smart led ceiling fan will be 

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -63,7 +63,7 @@ Then you need to set it up with yaml.
         # turn off the light as early as possible
         then:
           - light.turn_off: ifan02_light
-    
+
     wifi:
       ssid: <YOUR_SSID>
       password: <YOUR_PASSWORD>

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -1,14 +1,18 @@
-Ifan02
-======
+Sonoff iFan02
+=============
 
 .. seo::
     :description: Instructions for using Sonoff ifan02 in ESPHome.
     :keywords: Fan, Sonoff, ifan02
 
+Sonoff iFan02 is a driver for ceiling fans with lights. 
+By replacing the old driver with iFan02, your non-smart led ceiling fan will be 
+converted to a smart ceiling fan. 
+For more information see `iFan02 <https://www.itead.cc/sonoff-ifan02-wifi-smart-ceiling-fan-with-light.html>`__
 
-Configuration for `Sonoff ifan02 <https://www.itead.cc/sonoff-ifan02-wifi-smart-ceiling-fan-with-light.html>`__.
+This configuration will expose a :doc:`components/light/binary` and a :doc:`components/fan/speed`.
 
-First you need a :doc:`components/output/custom.html` to control the ifan02.
+To get this working in ESPHome you first need to create a :doc:`components/output/custom` to control the iFan02.
 
 Create a ifan02.h file:
 
@@ -17,30 +21,30 @@ Create a ifan02.h file:
     #include "esphome.h"
     using namespace esphome;
 
-    class IFan02Output : public Component, public output::FloatOutput {
+    class IFan02Output : public output::FloatOutput {
       public:
         void write_state(float state) override {
-            if (state < 0.3) {
-              digitalWrite(5, LOW);
-              digitalWrite(4, LOW);
-              digitalWrite(15, LOW);
-            }
-
-            if (state >= 0.32 && state <= 0.34) {
-              digitalWrite(5, HIGH);
-              digitalWrite(4, LOW);
-              digitalWrite(15, LOW);
-            }
-            if (state >= 0.65 && state <= 0.67) {
-              digitalWrite(5, HIGH);
-              digitalWrite(4, HIGH);
-              digitalWrite(15, LOW);
-            }
-            if (state >= 0.9) {
-              digitalWrite(5, HIGH);
-              digitalWrite(4, LOW);
-              digitalWrite(15, HIGH);
-            }
+          if (state < 0.3) {
+            // OFF
+            digitalWrite(5, LOW);
+            digitalWrite(4, LOW);
+            digitalWrite(15, LOW);
+          } else if (state < 0.6) {
+            // low speed
+            digitalWrite(5, HIGH);
+            digitalWrite(4, LOW);
+            digitalWrite(15, LOW);
+          } else if (state < 0.9) {
+            // medium speed
+            digitalWrite(5, HIGH);
+            digitalWrite(4, HIGH);
+            digitalWrite(15, LOW);
+          } else {
+            // high speed
+            digitalWrite(5, HIGH);
+            digitalWrite(4, LOW);
+            digitalWrite(15, HIGH);
+          }
         }
     };
 
@@ -179,3 +183,15 @@ Then you need to set it up with yaml.
         output: fanoutput
         id: ifan02
         name: ifan02_fan
+
+See Also
+--------
+
+- :doc:`/components/light/index`
+- :doc:`/components/light/binary`
+- :doc:`/components/fan`
+- :doc:`/components/fan/speed`
+- :doc:`/components/output/index`
+- :doc:`/components/output/custom`
+- :doc:`/guides/automations`
+- :ghedit:`Edit`

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -14,35 +14,35 @@ Create a ifan02.h file:
 
 .. code-block:: c++
 
-  #include "esphome.h"
-  using namespace esphome;
+    #include "esphome.h"
+    using namespace esphome;
 
-  class IFan02Output : public Component, public output::FloatOutput {
-    public:
-      void write_state(float state) override {
-          if (state < 0.3) {
-            digitalWrite(5, LOW);
-            digitalWrite(4, LOW);
-            digitalWrite(15, LOW);
-          }
+    class IFan02Output : public Component, public output::FloatOutput {
+      public:
+        void write_state(float state) override {
+            if (state < 0.3) {
+              digitalWrite(5, LOW);
+              digitalWrite(4, LOW);
+              digitalWrite(15, LOW);
+            }
 
-          if (state >= 0.32 && state <= 0.34) {
-            digitalWrite(5, HIGH);
-            digitalWrite(4, LOW);
-            digitalWrite(15, LOW);
-          }
-          if (state >= 0.65 && state <= 0.67) {
-            digitalWrite(5, HIGH);
-            digitalWrite(4, HIGH);
-            digitalWrite(15, LOW);
-          }
-          if (state >= 0.9) {
-            digitalWrite(5, HIGH);
-            digitalWrite(4, LOW);
-            digitalWrite(15, HIGH);
-          }
-      }
-  };
+            if (state >= 0.32 && state <= 0.34) {
+              digitalWrite(5, HIGH);
+              digitalWrite(4, LOW);
+              digitalWrite(15, LOW);
+            }
+            if (state >= 0.65 && state <= 0.67) {
+              digitalWrite(5, HIGH);
+              digitalWrite(4, HIGH);
+              digitalWrite(15, LOW);
+            }
+            if (state >= 0.9) {
+              digitalWrite(5, HIGH);
+              digitalWrite(4, LOW);
+              digitalWrite(15, HIGH);
+            }
+        }
+    };
 
 Then you need to set it up with yaml.
 

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -6,9 +6,8 @@ Sonoff iFan02
     :keywords: Fan, Sonoff, ifan02
     :image: fan.svg
 
-Sonoff iFan02 is a driver for ceiling fans with lights. 
-By replacing the old driver with iFan02, your non-smart led ceiling fan will be 
-converted to a smart ceiling fan. 
+Sonoff iFan02 is a driver for ceiling fans with lights.
+By replacing the old driver with iFan02, your non-smart led ceiling fan will be converted to a smart ceiling fan.
 For more information see `iFan02 <https://www.itead.cc/sonoff-ifan02-wifi-smart-ceiling-fan-with-light.html>`__
 
 This configuration will expose a :doc:`components/light/binary` and a :doc:`components/fan/speed`.

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -179,4 +179,3 @@ Then you need to set it up with yaml.
         output: fanoutput
         id: ifan02
         name: ifan02_fan
-

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -1,0 +1,182 @@
+Ifan02
+======
+
+.. seo::
+    :description: Instructions for using Sonoff ifan02 in ESPHome.
+    :keywords: Fan, Sonoff, ifan02
+
+
+Configuration for `Sonoff ifan02 <https://www.itead.cc/sonoff-ifan02-wifi-smart-ceiling-fan-with-light.html>`__.
+
+First you need a :doc:`components/output/custom.html` to control the ifan02.
+
+Create a ifan02.h file:
+
+.. code-block:: c++
+
+  #include "esphome.h"
+  using namespace esphome;
+
+  class IFan02Output : public Component, public output::FloatOutput {
+    public:
+      void write_state(float state) override {
+          if (state < 0.3) {
+            digitalWrite(5, LOW);
+            digitalWrite(4, LOW);
+            digitalWrite(15, LOW);
+          }
+
+          if (state >= 0.32 && state <= 0.34) {
+            digitalWrite(5, HIGH);
+            digitalWrite(4, LOW);
+            digitalWrite(15, LOW);
+          }
+          if (state >= 0.65 && state <= 0.67) {
+            digitalWrite(5, HIGH);
+            digitalWrite(4, HIGH);
+            digitalWrite(15, LOW);
+          }
+          if (state >= 0.9) {
+            digitalWrite(5, HIGH);
+            digitalWrite(4, LOW);
+            digitalWrite(15, HIGH);
+          }
+      }
+  };
+
+Then you need to set it up with yaml.
+
+.. code-block:: yaml
+
+    esphome:
+      name: ifan02
+      platform: ESP8266
+      board: esp8285
+      includes:
+        - ifan02.h
+    
+    binary_sensor:
+      - platform: gpio
+        id: vbutton_light
+        pin: 
+          number: GPIO0
+          inverted: True
+        on_press:
+          then:
+            - light.toggle: light
+    
+      - platform: gpio
+        id: vbutton_relay_1
+        pin: 
+          number: GPIO9
+          inverted: True
+        on_press:
+          then:
+            - switch.toggle: fan_relay1
+            - switch.turn_on: update_fan_speed
+    
+      - platform: gpio
+        id: vbutton_relay_2
+        pin: 
+          number: GPIO10
+          inverted: True
+        on_press:
+          then:
+            - switch.toggle: fan_relay2
+            - switch.turn_on: update_fan_speed
+            
+      - platform: gpio
+        id: vbutton_relay_3
+        pin: 
+          number: GPIO14
+          inverted: True
+        on_press:
+          then:
+            - switch.toggle: fan_relay3
+            - switch.turn_on: update_fan_speed
+    
+    output:
+      - platform: custom
+        type: float
+        outputs:
+          id: fanoutput
+        lambda: |-
+          auto ifan02 = new IFan02Output();
+          App.register_component(ifan02);
+          return {ifan02};
+          
+      - platform: gpio
+        pin: GPIO12
+        id: light_output
+    
+    light:
+      - platform: binary
+        name: ifan02_light
+        output: light_output
+        id: light
+    
+    switch:
+      - platform: template
+        id: update_fan_speed
+        optimistic: True
+        turn_on_action:
+          then:
+            - delay: 200ms
+            - if: 
+                condition:
+                  and:
+                    - switch.is_off: fan_relay1
+                    - switch.is_off: fan_relay2
+                    - switch.is_off: fan_relay3
+                then:
+                  - fan.turn_off: ifan02
+            - if:
+                condition:
+                  and:
+                    - switch.is_on: fan_relay1
+                    - switch.is_off: fan_relay2
+                    - switch.is_off: fan_relay3
+                then:
+                  - fan.turn_on: 
+                      id: ifan02
+                      speed: LOW
+            - if:
+                condition:
+                  and:
+                    - switch.is_on: fan_relay1
+                    - switch.is_on: fan_relay2
+                    - switch.is_off: fan_relay3
+                then:
+                  - fan.turn_on: 
+                      id: ifan02
+                      speed: MEDIUM
+            - if:
+                condition:
+                  and:
+                    - switch.is_on: fan_relay1
+                    - switch.is_off: fan_relay2
+                    - switch.is_on: fan_relay3
+                then:
+                  - fan.turn_on: 
+                      id: ifan02
+                      speed: HIGH
+            - switch.turn_off: update_fan_speed
+    
+      - platform: gpio
+        pin: GPIO5
+        id: fan_relay1
+        
+      - platform: gpio
+        pin: GPIO4
+        id: fan_relay2
+        
+      - platform: gpio
+        pin: GPIO15
+        id: fan_relay3
+    
+    fan:
+      - platform: speed
+        output: fanoutput
+        id: ifan02
+        name: ifan02_fan
+

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -21,7 +21,7 @@ Create a ifan02.h file:
     #include "esphome.h"
     using namespace esphome;
 
-    class IFan02Output : public output::FloatOutput {
+    class IFan02Output : public Component, public FloatOutput {
       public:
         void write_state(float state) override {
           if (state < 0.3) {
@@ -58,6 +58,21 @@ Then you need to set it up with yaml.
       board: esp8285
       includes:
         - ifan02.h
+      on_boot:
+        priority: 225
+        # turn off the light as early as possible
+        then:
+          - light.turn_off: ifan02_light
+    
+    wifi:
+      ssid: <YOUR_SSID>
+      password: <YOUR_PASSWORD>
+
+    api:
+
+    logger:
+
+    ota:
 
     binary_sensor:
       - platform: gpio
@@ -67,7 +82,7 @@ Then you need to set it up with yaml.
           inverted: True
         on_press:
           then:
-            - light.toggle: light
+            - light.toggle: ifan02_light
 
       - platform: gpio
         id: vbutton_relay_1
@@ -105,9 +120,9 @@ Then you need to set it up with yaml.
         outputs:
           id: fanoutput
         lambda: |-
-          auto ifan02 = new IFan02Output();
-          App.register_component(ifan02);
-          return {ifan02};
+          auto ifan02_fan = new IFan02Output();
+          App.register_component(ifan02_fan);
+          return {ifan02_fan};
 
       - platform: gpio
         pin: GPIO12
@@ -115,9 +130,9 @@ Then you need to set it up with yaml.
 
     light:
       - platform: binary
-        name: ifan02_light
+        name: "iFan02 Light"
         output: light_output
-        id: light
+        id: ifan02_light
 
     switch:
       - platform: template
@@ -133,7 +148,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay2
                     - switch.is_off: fan_relay3
                 then:
-                  - fan.turn_off: ifan02
+                  - fan.turn_off: ifan02_fan
             - if:
                 condition:
                   and:
@@ -142,7 +157,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay3
                 then:
                   - fan.turn_on:
-                      id: ifan02
+                      id: ifan02_fan
                       speed: LOW
             - if:
                 condition:
@@ -152,7 +167,7 @@ Then you need to set it up with yaml.
                     - switch.is_off: fan_relay3
                 then:
                   - fan.turn_on:
-                      id: ifan02
+                      id: ifan02_fan
                       speed: MEDIUM
             - if:
                 condition:
@@ -162,7 +177,7 @@ Then you need to set it up with yaml.
                     - switch.is_on: fan_relay3
                 then:
                   - fan.turn_on:
-                      id: ifan02
+                      id: ifan02_fan
                       speed: HIGH
             - switch.turn_off: update_fan_speed
 
@@ -181,8 +196,8 @@ Then you need to set it up with yaml.
     fan:
       - platform: speed
         output: fanoutput
-        id: ifan02
-        name: ifan02_fan
+        id: ifan02_fan
+        name: "iFan02 Fan"
 
 See Also
 --------

--- a/index.rst
+++ b/index.rst
@@ -295,6 +295,7 @@ Cookbook
     Mirabella Genio Bulb, cookbook/mirabella-genio-bulb, cookbook-mirabella-genio-b22-rgbw.jpg
     Garage Door, cookbook/garage-door, window-open.svg
     Brilliant / Mirabella Genio Smart Plugs, cookbook/brilliant-mirabella-genio-smart-plugs, cookbook-brilliant-mirabella-genio-smart-plugs.jpg
+    Sonoff iFan02, cookbook/ifan02, fan.svg
 
 Do you have other awesome automations or cool setups? Please feel free to add them to the
 documentation for others to copy. See :doc:`Contributing </guides/contributing>`.


### PR DESCRIPTION
## Description:
Fix doc links (hopefully)
Added a ```/``` to the doc links on lines 13 & 15 to match the way they are in the "See Also" section the bottom. 
Hopefully this will fix the travis-ci & netlify errors.
Editing .rst is painful 😉 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
