### PR TITLE
fix doc links (in the right repo)

### DIFF
--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -10,9 +10,9 @@ Sonoff iFan02 is a driver for ceiling fans with lights.
 By replacing the old driver with iFan02, your non-smart led ceiling fan will be converted to a smart ceiling fan.
 For more information see `iFan02 <https://www.itead.cc/sonoff-ifan02-wifi-smart-ceiling-fan-with-light.html>`__
 
-This configuration will expose a :doc:`components/light/binary` and a :doc:`components/fan/speed`.
+This configuration will expose a :doc:`/components/light/binary` and a :doc:`/components/fan/speed`.
 
-To get this working in ESPHome you first need to create a :doc:`components/output/custom` to control the iFan02.
+To get this working in ESPHome you first need to create a :doc:`/components/output/custom` to control the iFan02.
 
 Create a ifan02.h file:
 


### PR DESCRIPTION
I think my last PR was made against the wrong fork/branch/etc... it looks like the merge didn't change anything in your PR to the ESPHome Docs. Sorry, I'm still learning github.

I currently have the time and really want to see this make it into the cookbook. I think if you add me as a collaborator I would be able to push the changes and help get the errors sorted more quickly; if not, no worries, I'll take no offense and do my best to continue helping as we are doing now.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
